### PR TITLE
Use light oil overlay from K2 if playing with K2

### DIFF
--- a/prototypes/phenol.lua
+++ b/prototypes/phenol.lua
@@ -73,6 +73,12 @@ if data.raw.item["coke"] then
   else
     util.add_effect("basic-chemistry", {type="unlock-recipe", recipe="phenol"})
   end
+
+  if mods.Krastorio2 then
+    light_oil_icon = { icon = "__Krastorio2Assets__/icons/fluids/light-oil.png", icon_size = 64, icon_mipmaps = 4, scale=0.25, shift={-8,-8}}
+  else
+    light_oil_icon = { icon = "__base__/graphics/icons/fluid/light-oil.png", icon_size = 64, icon_mipmaps = 4, scale=0.25, shift={-8,-8}}
+  end
   data:extend({
     {
       type = "recipe",
@@ -82,7 +88,7 @@ if data.raw.item["coke"] then
       enabled = "false",
       icons = {
         {icon = "__bzgas__/graphics/icons/phenol.png", icon_size = 128},
-        {icon = "__base__/graphics/icons/fluid/light-oil.png", icon_size = 64, icon_mipmaps = 4, scale=0.25, shift={-8,-8}},
+        light_oil_icon,
       },
       ingredients = {
         {type="fluid", name="light-oil", amount=20}


### PR DESCRIPTION
Phenol recipe which uses light oil has an light oil overlay.
This PR changes the overlay to K2's if playing with K2.

Before (with or without K2):
<img width="39" alt="phenol-with-vanilla-light-oil-overlay" src="https://github.com/sakuro/bzgas/assets/10973/152838f5-ad14-459c-957d-91905a5833ca">

After (with K2):
<img width="38" alt="phenol-with-k2-light-oil-overlay" src="https://github.com/sakuro/bzgas/assets/10973/dfe306fb-bf66-42de-9b95-c0c92ebcab7f">
